### PR TITLE
fix: prevent UI lock when token refresh hangs

### DIFF
--- a/lib/core/http/custom_dio.dart
+++ b/lib/core/http/custom_dio.dart
@@ -68,6 +68,7 @@ class CustomDio {
         baseUrl: Config.baseUrl,
         connectTimeout: const Duration(seconds: 15),
         receiveTimeout: const Duration(seconds: 15),
+        sendTimeout: const Duration(seconds: 15),
         validateStatus: (status) {
           return status! < 500 && status != 401 && status != 403;
         },

--- a/lib/core/http/interceptors/security_interceptor.dart
+++ b/lib/core/http/interceptors/security_interceptor.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:jwt_decoder/jwt_decoder.dart';
@@ -27,10 +29,10 @@ class SecurityInterceptor extends Interceptor {
     required Dio retryDio,
     required Future<String?> Function() onRefresh,
     required AuthNotifier authNotifier,
-  })  : _storage = storage,
-        _retryDio = retryDio,
-        _onRefresh = onRefresh,
-        _authNotifier = authNotifier;
+  }) : _storage = storage,
+       _retryDio = retryDio,
+       _onRefresh = onRefresh,
+       _authNotifier = authNotifier;
 
   // ── onRequest: verificação PROATIVA ──────────────────────────────────────
 
@@ -71,9 +73,7 @@ class SecurityInterceptor extends Interceptor {
       options.headers['Authorization'] = 'Bearer $token';
     }
 
-    debugPrint(
-      '[AuthDebug][$requestId] Injecting token into ${options.path}',
-    );
+    debugPrint('[AuthDebug][$requestId] Injecting token into ${options.path}');
     handler.next(options);
   }
 
@@ -103,7 +103,10 @@ class SecurityInterceptor extends Interceptor {
           ? authHeader!.substring(7)
           : null;
 
-      final newToken = await _refreshUnderLock(requestId, knownToken: sentToken);
+      final newToken = await _refreshUnderLock(
+        requestId,
+        knownToken: sentToken,
+      );
       if (newToken == null) {
         debugPrint(
           '[AuthDebug][$requestId] Refresh returned null. Cannot retry.',
@@ -178,7 +181,10 @@ class SecurityInterceptor extends Interceptor {
         '[AuthDebug][$requestId] Access token expired. Attempting refresh...',
       );
       try {
-        return await _onRefresh();
+        return await _onRefresh().timeout(const Duration(seconds: 10));
+      } on TimeoutException catch (_) {
+        debugPrint('[AuthDebug][$requestId] Refresh timed out after 10s.');
+        return null;
       } catch (e) {
         debugPrint('[AuthDebug][$requestId] Refresh threw: $e');
         return null;

--- a/lib/pages/devices/device_register/widgets/device_register_form.dart
+++ b/lib/pages/devices/device_register/widgets/device_register_form.dart
@@ -28,8 +28,9 @@ class _DeviceRegisterFormState extends State<DeviceRegisterForm> {
     if (!_formKey.currentState!.validate()) return;
     _formKey.currentState?.save();
 
-    int? deviceId =
-        await context.read<DeviceRegisterController>().createDevice();
+    int? deviceId = await context
+        .read<DeviceRegisterController>()
+        .createDevice();
     if (deviceId != null && context.mounted) {
       WsNavigator.pushDeviceDetails(context, deviceId, replaced: true);
     }
@@ -83,8 +84,11 @@ class _DeviceRegisterFormState extends State<DeviceRegisterForm> {
 class DeviceRegisterActionButtons extends StatelessWidget {
   final VoidCallback onCancel;
   final Future<void> Function() onSave;
-  const DeviceRegisterActionButtons(
-      {super.key, required this.onCancel, required this.onSave});
+  const DeviceRegisterActionButtons({
+    super.key,
+    required this.onCancel,
+    required this.onSave,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -121,10 +125,11 @@ class DeviceRegisterActionButtons extends StatelessWidget {
               selector: (context, controller) => controller.isCreatingDevice,
               builder: (context, isCreatingDevice, child) {
                 return SizedBox(
-                  width: 220,
+                  width: 225,
                   child: ElevatedButton.icon(
-                    onPressed:
-                        isCreatingDevice ? null : () async => await onSave(),
+                    onPressed: isCreatingDevice
+                        ? null
+                        : () async => await onSave(),
                     style: ElevatedButton.styleFrom(
                       padding: const EdgeInsets.symmetric(
                         horizontal: 32,
@@ -142,12 +147,13 @@ class DeviceRegisterActionButtons extends StatelessWidget {
                     label: isCreatingDevice
                         ? const Center(
                             child: SizedBox(
-                            width: 20,
-                            height: 20,
-                            child: CircularProgressIndicator(
-                              color: Colors.black87,
+                              width: 20,
+                              height: 20,
+                              child: CircularProgressIndicator(
+                                color: Colors.black87,
+                              ),
                             ),
-                          ))
+                          )
                         : const Text('Cadastrar Aparelho'),
                   ),
                 );


### PR DESCRIPTION
- Add sendTimeout to Dio base config (15s) to prevent hang on request body upload
- Add 10s timeout to _onRefresh() in SecurityInterceptor to ensure Lock is released even if the refresh HTTP call never completes
- Fix formatting in device_register_form.dart